### PR TITLE
Allow to define specific HTTP and ZMQ ports

### DIFF
--- a/include/EigerCamera.h
+++ b/include/EigerCamera.h
@@ -73,7 +73,7 @@ class LIBEIGER Camera : public HwMaxImageSizeCallbackGen, public EventCallbackGe
   enum Status { Initializing, Ready, Armed, Exposure, Fault };
   enum CompressionType {NoCompression,LZ4,BSLZ4};
 
-  Camera(const std::string& detector_ip);
+  Camera(const std::string& host, int http_port=80, int stream_port=9999);
   ~Camera();
 
   void initialize();
@@ -159,7 +159,8 @@ class LIBEIGER Camera : public HwMaxImageSizeCallbackGen, public EventCallbackGe
   void deleteMemoryFiles();
   void disarm();
 
-  const std::string& getDetectorIp() const;
+  const std::string& getDetectorHost() const;
+  int getDetectorStreamPort() const;
 
  private:
   friend class Interface;
@@ -249,7 +250,9 @@ class LIBEIGER Camera : public HwMaxImageSizeCallbackGen, public EventCallbackGe
   double                    m_readout_time;
   double                    m_x_pixelsize, m_y_pixelsize;
   Cond                      m_cond;
-  std::string               m_detector_ip;
+  std::string               m_detector_host;
+  int                       m_detector_http_port;
+  int                       m_detector_stream_port;
   double                    m_min_frame_time;
   CompressionType           m_compression_type;
 };

--- a/sip/EigerCamera.sip
+++ b/sip/EigerCamera.sip
@@ -32,7 +32,7 @@ namespace Eiger
     enum Status { Initializing, Ready, Armed, Exposure, Fault };
     enum CompressionType {NoCompression,LZ4,BSLZ4};
 
-    Camera(const std::string& detector_ip);
+    Camera(const std::string& detector_ip, int http_port = 80, int stream_port = 9999);
     ~Camera();
 
     void initialize();

--- a/src/EigerCamera.cpp
+++ b/src/EigerCamera.cpp
@@ -101,7 +101,7 @@ private:
 //-----------------------------------------------------------------------------
 ///  Ctor
 //-----------------------------------------------------------------------------
-Camera::Camera(const std::string& detector_ip) 	///< [in] Ip address of the detector server
+Camera::Camera(const std::string& host, int http_port, int stream_port)	///< [in] Ip address of the detector server
   : 		m_frames_triggered(0),
 		m_frames_acquired(0),
                 m_latency_time(0.),
@@ -110,12 +110,16 @@ Camera::Camera(const std::string& detector_ip) 	///< [in] Ip address of the dete
 		m_trigger_state(IDLE),
 		m_armed(false),
 		m_serie_id(0),
-                m_requests(new Requests(detector_ip)),
                 m_exp_time(1.),
-		m_detector_ip(detector_ip)
+                m_detector_host(host),
+                m_detector_http_port(http_port),
+                m_detector_stream_port(stream_port)
 {
     DEB_CONSTRUCTOR();
-    DEB_PARAM() << DEB_VAR1(detector_ip);
+    DEB_PARAM() << DEB_VAR1(host);
+
+    std::string http_address = host + ":" + std::to_string(http_port);
+    m_requests = new Requests(http_address);
 
     // Detect EigerAPI version
     std::string api_version = m_requests->get_api_version();
@@ -1170,7 +1174,13 @@ void Camera::disarm()
   sendCommand(Requests::DISARM);
 }
 
-const std::string& Camera::getDetectorIp() const
+const std::string& Camera::getDetectorHost() const
 {
-  return m_detector_ip;
+  return m_detector_host;
 }
+
+int Camera::getDetectorStreamPort() const
+{
+  return m_detector_stream_port;
+}
+

--- a/src/EigerStream.cpp
+++ b/src/EigerStream.cpp
@@ -263,7 +263,8 @@ void Stream::_ZmqThread::_run_sequence()
 
   char stream_endpoint[256];
   snprintf(stream_endpoint,sizeof(stream_endpoint),
-	   "tcp://%s:9999",cam.getDetectorIp().c_str());
+           "tcp://%s:%d",cam.getDetectorHost().c_str(),
+           cam.getDetectorStreamPort());
   if(zmq_connect(stream_socket,stream_endpoint) != 0) {
     char error_buffer[256];
     const char *error_msg = strerror_r(errno,error_buffer,sizeof(error_buffer));


### PR DESCRIPTION
Hi,

"Soon" ALBA will have an Eiger detector.
Right now, we started making some tests using an [eiger simulator](http://github.com/tiagocoutinho/eiger-simulator) using a sample dectris dataset.
We fire up the simulator using configurable http port (default 8000) and zmq port (default 9999) to avoid the need of admin privileges for launching on port 80.

This PR makes it possible to create a Lima Eiger Camera object with optional http port and zmq port parameters so it can connect to a simulator for example.